### PR TITLE
ci(CI): Protect reporting of build test status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,13 @@ jobs:
             set -exo pipefail
             cargo release -vvv --execute --no-confirm "$(nextsv -vvv -e feature -r 'CHANGES.md' -r 'CHANGELOG.md')"
 
+  happy-ending:
+    executor: rust-env
+    steps:
+      - run:
+          name: happy ending to ensure that not being ready for a release does not mark the crate tests as failing
+          command: exit 0
+
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
@@ -138,4 +145,5 @@ workflows:
       - make-release:
           requires:
             - release-ready
+      - happy-ending
 # VS Code Extension Version: 1.4.0


### PR DESCRIPTION
Protects the build status by ensuring that the regularly run release tests do not result in a failing release when there are  no qualifying changes to trigger a release or the release has not been successful