### PR TITLE
feat(ci): add commands for GitHub and Cargo release processes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,266 @@ executors:
   base-env:
     docker:
       - image: jerusdp/ci-rust:base
+commands:
+  make_github_release:
+    parameters:
+      pcu_verbosity:
+        type: string
+        default: "-vv"
+        description: "The verbosity of the pcu command"
+      pcu_update_changelog:
+        type: boolean
+        default: false
+        description: "The verbosity of the pcu command"
+      pcu_prefix:
+        type: string
+        default: "v"
+        description: "The verbosity of the pcu command"
+      pcu_workspace:
+        type: boolean
+        default: false
+        description: "Whether or not to set the workspace flag of the pcu command"
+      pcu_package:
+        type: string
+        default: ""
+        description: "Package to release and/or publish"
+    steps:
+      - run:
+          name: Create Github release
+          command: |
+            set -exo pipefail
+
+            if [ << parameters.pcu_package >> != "" ] ; then
+                package="--package << parameters.pcu_package >>"
+                # prefix="<< parameters.pcu_package >>-<< parameters.pcu_prefix >> "
+                pcu <<parameters.pcu_verbosity>> release $update_changelog $package --prefix <<parameters.pcu_prefix>> 
+                exit
+            fi
+
+            if [ <<parameters.pcu_workspace>> == true ] ; then
+                pcu <<parameters.pcu_verbosity>> release $update_changelog --prefix <<parameters.pcu_prefix>> --workspace
+                exit
+            fi
+
+            if [ "" != "${SEMVER}" ] ; then
+              if [ <<parameters.pcu_update_changelog>> == true ] ; then
+                update_changelog="-update_changelog"
+              else
+                update_changelog=""
+              fi
+              pcu <<parameters.pcu_verbosity>> release $update_changelog --prefix <<parameters.pcu_prefix>> --semver ${SEMVER}
+            fi
+
+  make_cargo_release:
+    parameters:
+      publish:
+        type: boolean
+        default: true
+        description: "If true, the release will be published."
+      first_release:
+        type: boolean
+        default: false
+        description: "If true, the release will be published as first release."
+      specific_version:
+        type: boolean
+        default: false
+        description: "If true, the release will be published with a specific version."
+      version:
+        type: string
+        default: ""
+        description: "Specific version number to release"
+      no_push:
+        type: boolean
+        default: false
+        description: "Whether or not cargo release should push the changes"
+      package:
+        type: string
+        default: ""
+        description: "Package to release and/or publish"
+    steps:
+      - run:
+          name: Find next level and publish update
+          command: |
+            set -exo pipefail
+
+            if [ << parameters.package >> != "" ] ; then
+              package="--package << parameters.package >>"
+            fi
+
+            if [ << parameters.publish >> == true ] ; then
+              publish="--publish"
+            else
+              publish="--no-publish"
+            fi
+
+            cargo release changes
+            if [ << parameters.first_release >> == true ] ; then
+              cargo release $package $publish --execute --no-confirm --sign-tag -c first-release.toml 0.1.0
+            else
+              if [ << parameters.specific_version >> == true ] && [ "<< parameters.version >>" != "" ] ; then
+                export NEXTSV_LEVEL=<< parameters.version >>
+              else
+                export NEXTSV_LEVEL=$(nextsv -q -c other require -f CHANGELOG.md feature)
+              fi
+              echo $NEXTSV_LEVEL
+              if [ $NEXTSV_LEVEL != "none" ] ; then
+                cargo release changes
+                if [ << parameters.no_push >> == true ] ; then
+                  cargo release $package $publish --no-push --execute --no-confirm --sign-tag "$NEXTSV_LEVEL"
+                else
+                  cargo release $package $publish --execute --no-confirm --sign-tag "$NEXTSV_LEVEL"
+                fi
+              else
+                echo "Not ready to release yet."
+                circleci step halt
+              fi
+            fi
+
+jobs:
+  make_release:
+    executor:
+      name: rust-env
+
+    parameters:
+      ssh_fingerprint:
+        type: string
+      min_rust_version:
+        type: string
+      pcu_verbosity:
+        type: string
+        default: "-vv"
+        description: "The verbosity of the pcu command"
+      version:
+        type: string
+        default: ""
+        description: |
+          Specific version number to release
+      specific_version:
+        type: boolean
+        default: false
+        description: |
+          Make a specific release, if true version must be set to the specific version number
+      first_release:
+        type: boolean
+        default: false
+        description: |
+          Request that a first release (v0.1.0) be created
+      publish:
+        type: boolean
+        default: true
+        description: |
+          Publish the release
+      github_release:
+        type: boolean
+        default: true
+        description: |
+          Create a github release
+      cargo_release:
+        type: boolean
+        default: true
+        description: |
+          Create a cargo release
+      update_pcu:
+        type: boolean
+        default: false
+        description: |
+          Update pcu
+      pcu_update_changelog:
+        type: boolean
+        default: false
+        description: "To update the changelog when making the github release"
+      pcu_push:
+        type: boolean
+        default: false
+        description: "To use the pcu push command"
+      pcu_semver:
+        type: boolean
+        default: false
+        description: "Whether or not set the semver version flag"
+      pcu_no_push:
+        type: boolean
+        default: false
+        description: "Whether or not prevent final push of commit"
+      pcu_commit_message:
+        type: string
+        default: "chore: test push"
+        description: "The commit message to use for the pcu test push"
+      pcu_prefix:
+        type: string
+        default: "v"
+        description: "The verbosity of the pcu command"
+      pcu_workspace:
+        type: boolean
+        default: false
+        description: "Whether or not to set the workspace flag of the pcu command"
+      package:
+        type: string
+        default: ""
+        description: "The package to publish"
+
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - << parameters.ssh_fingerprint >>
+      - run:
+          name: Remove original SSH key from agent
+          command: |
+            ssh-add -l
+            ssh-add -d ~/.ssh/id_rsa.pub
+            ssh-add -l
+      - toolkit/gpg_key
+      - toolkit/git_config
+      - when:
+          condition: << parameters.update_pcu >>
+          steps:
+            - toolkit/install_latest_pcu
+      - when:
+          condition: << parameters.github_release >>
+          steps:
+            - toolkit/set_env_var_semver:
+                version: << parameters.version >>
+      - when:
+          condition:
+            and:
+              - << parameters.cargo_release >>
+              - not: << parameters.pcu_push >>
+          steps:
+            - make_cargo_release:
+                publish: << parameters.publish >>
+                first_release: << parameters.first_release >>
+                specific_version: << parameters.specific_version >>
+                version: << parameters.version >>
+                package: << parameters.package >>
+      - when:
+          condition:
+            and:
+              - << parameters.cargo_release >>
+              - << parameters.pcu_push >>
+          steps:
+            - make_cargo_release:
+                publish: << parameters.publish >>
+                first_release: << parameters.first_release >>
+                specific_version: << parameters.specific_version >>
+                version: << parameters.version >>
+                package: << parameters.package >>
+                no_push: true
+      - when:
+          condition: < parameters.pcu_push >>
+          steps:
+            - toolkit/push_cmd:
+                pcu_no_push: << parameters.pcu_no_push >>
+                pcu_verbosity: << parameters.pcu_verbosity >>
+                pcu_semver: << parameters.pcu_semver >>
+      - when:
+          condition: < parameters.github_release >>
+          steps:
+            - make_github_release:
+                pcu_verbosity: << parameters.pcu_verbosity >>
+                pcu_update_changelog: << parameters.pcu_update_changelog >>
+                pcu_prefix: << parameters.pcu_prefix >>
+                pcu_workspace: << parameters.pcu_workspace >>
+                pcu_package: << parameters.package >>
 
 workflows:
   check_last_commit:
@@ -100,11 +360,12 @@ workflows:
         - not: << pipeline.parameters.success-flag >>
         - not: << pipeline.parameters.validation-flag >>
     jobs:
-      - toolkit/make_release:
+      - make_release:
           context:
             - release
             - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
           specific_version: true
-          version: "9.0.1"
+          version: "9.0.2"
+          package: nextsv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- add commands for GitHub and Cargo release processes(pr [#225])
+
 ## [9.0.1] - 2024-10-29
 
 ### Added
@@ -751,7 +757,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#222]: https://github.com/jerus-org/nextsv/pull/222
 [#223]: https://github.com/jerus-org/nextsv/pull/223
 [#224]: https://github.com/jerus-org/nextsv/pull/224
-[9.0.1]: https://github.com/jerus-org/nextsv/compare/v0.8.22...nextsv-v9.0.1
+[#225]: https://github.com/jerus-org/nextsv/pull/225
+[Unreleased]: https://github.com/jerus-org/nextsv/compare/v9.0.1...HEAD
+[9.0.1]: https://github.com/jerus-org/nextsv/compare/v0.8.22...v9.0.1
 [0.8.22]: https://github.com/jerus-org/nextsv/compare/v0.8.21...v0.8.22
 [0.8.21]: https://github.com/jerus-org/nextsv/compare/v0.8.20...v0.8.21
 [0.8.20]: https://github.com/jerus-org/nextsv/compare/v0.8.19...v0.8.20


### PR DESCRIPTION
Add new commands `make_github_release` and `make_cargo_release` to automate GitHub and Cargo release processes, with parameters for verbosity, changelog updates, versioning, and package management. Integrate these commands into the `make_release` job for streamlined release workflows.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change logs have been updated
