### PR TITLE
chore: migrate to circleci-toolkit v4.0.1 with rolling images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,27 @@
 version: 2.1
 
 parameters:
-  min-rust-version:
+  min_rust_version:
     type: string
     default: "1.82"
   fingerprint:
     type: string
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
-  validation-flag:
+  validation_flag:
     type: boolean
     default: false
     description: "If true, the validation pipeline will be executed."
-  success-flag:
+  success_flag:
     type: boolean
     default: false
     description: "If true, the success pipeline will be executed."
-  release-flag:
+  release_flag:
     type: boolean
     default: false
     description: "If true, the release workflow will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@3.2.0
+  toolkit: jerus-org/circleci-toolkit@4.0.1
 
 workflows:
   check_last_commit:
@@ -29,9 +29,9 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.success-flag >>
-        - not: << pipeline.parameters.release-flag >>
-        - not: << pipeline.parameters.validation-flag >>
+        - not: << pipeline.parameters.success_flag >>
+        - not: << pipeline.parameters.release_flag >>
+        - not: << pipeline.parameters.validation_flag >>
 
     jobs:
       - toolkit/choose_pipeline:
@@ -43,28 +43,28 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.success-flag >>
-        - << pipeline.parameters.validation-flag >>
-        - not: << pipeline.parameters.release-flag >>
+        - not: << pipeline.parameters.success_flag >>
+        - << pipeline.parameters.validation_flag >>
+        - not: << pipeline.parameters.release_flag >>
     jobs:
       - toolkit/label:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
           context: pcu-app
           filters:
             branches:
               only:
                 - main
       - toolkit/code_coverage:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
           package: nextsv
       - toolkit/required_builds:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
       - toolkit/optional_builds:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
       - toolkit/test_doc_build:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
       - toolkit/idiomatic_rust:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
       - toolkit/security:
           context: SonarCloud
       - toolkit/update_prlog:
@@ -78,16 +78,16 @@ workflows:
             - release
             - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
 
   on_success:
     when:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - << pipeline.parameters.success-flag >>
-        - not: << pipeline.parameters.validation-flag >>
-        - not: << pipeline.parameters.release-flag >>
+        - << pipeline.parameters.success_flag >>
+        - not: << pipeline.parameters.validation_flag >>
+        - not: << pipeline.parameters.release_flag >>
 
     jobs:
       - toolkit/end_success
@@ -99,12 +99,12 @@ workflows:
             - and:
                 - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
                 - equal: ["release check", << pipeline.schedule.name >>]
-            - << pipeline.parameters.release-flag >>
-        - not: << pipeline.parameters.success-flag >>
-        - not: << pipeline.parameters.validation-flag >>
+            - << pipeline.parameters.release_flag >>
+        - not: << pipeline.parameters.success_flag >>
+        - not: << pipeline.parameters.validation_flag >>
     jobs:
       - toolkit/save_next_version:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
           package: nextsv
           install_me: true
           path_to_crate: "./crates/nextsv"
@@ -126,12 +126,12 @@ workflows:
             - release
             - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
           package: nextsv
           when_use_workspace: false
 
       - toolkit/no_release:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
           requires:
             - toolkit/save_next_version:
                 - failed

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(git_utils)-enhance find_last_commit function signature(pr [#375])
 - chore-rename CHANGELOG.md to PRLOG.md(pr [#376])
 - 👷 ci(circleci)-update circleci toolkit orb version(pr [#384])
+- chore-migrate to circleci-toolkit v4.0.1 with rolling images(pr [#409])
 
 ### Fixed
 
@@ -1349,6 +1350,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#404]: https://github.com/jerus-org/nextsv/pull/404
 [#406]: https://github.com/jerus-org/nextsv/pull/406
 [#407]: https://github.com/jerus-org/nextsv/pull/407
+[#409]: https://github.com/jerus-org/nextsv/pull/409
 [Unreleased]: https://github.com/jerus-org/nextsv/compare/v0.19.24...HEAD
 [0.19.24]: https://github.com/jerus-org/nextsv/compare/v0.19.23...v0.19.24
 [0.19.23]: https://github.com/jerus-org/nextsv/compare/v0.19.22...v0.19.23


### PR DESCRIPTION
## Summary

- Update toolkit from 3.2.0 to 4.0.1
- Convert pipeline parameters from kebab-case to snake_case (required by v4)

## Changes in v4.0.1

This version introduces:
- Digest-pinned rolling 6-month container images for immutable, reproducible builds
- Automatic MSRV fallback via `select_rust_version` command
- snake_case pipeline parameters (breaking change from v3.x)

## Parameters Renamed

| Before (kebab-case) | After (snake_case) |
|---------------------|---------------------|
| `min-rust-version` | `min_rust_version` |
| `validation-flag` | `validation_flag` |
| `success-flag` | `success_flag` |
| `release-flag` | `release_flag` |

## Test plan

- [ ] CI pipeline passes with renamed parameters
- [ ] All workflow conditions evaluate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)