### PR TITLE
ci: migrate to toolkit v4.0.1 and post-merge prlog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
     description: "If true, the release workflow will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.0.1
+  toolkit: jerus-org/circleci-toolkit@4.2.0
 
 workflows:
   check_last_commit:
@@ -67,7 +67,7 @@ workflows:
           min_rust_version: << pipeline.parameters.min_rust_version >>
       - toolkit/security:
           context: SonarCloud
-      - toolkit/trigger_success_pipeline:
+      - toolkit/trigger_pipeline:
           requires:
             - toolkit/required_builds
             - toolkit/test_doc_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ workflows:
           min_rust_version: << pipeline.parameters.min_rust_version >>
       - toolkit/security:
           context: SonarCloud
-      - toolkit/update_prlog:
+      - toolkit/trigger_success_pipeline:
           requires:
             - toolkit/required_builds
             - toolkit/test_doc_build
@@ -75,10 +75,11 @@ workflows:
             - toolkit/security
             - toolkit/code_coverage
           context:
-            - release
             - bot-check
-          ssh_fingerprint: << pipeline.parameters.fingerprint >>
-          min_rust_version: << pipeline.parameters.min_rust_version >>
+          filters:
+            branches:
+              ignore:
+                - main
 
   on_success:
     when:
@@ -135,3 +136,25 @@ workflows:
           requires:
             - toolkit/save_next_version:
                 - failed
+
+  post_merge_main:
+    when:
+      and:
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - not: << pipeline.parameters.success_flag >>
+        - not: << pipeline.parameters.validation_flag >>
+        - not: << pipeline.parameters.release_flag >>
+
+    jobs:
+      - toolkit/update_prlog:
+          context:
+            - release
+            - bot-check
+          ssh_fingerprint: << pipeline.parameters.fingerprint >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
+          update_log_option: halt
+          filters:
+            branches:
+              only:
+                - main


### PR DESCRIPTION
## Summary

- Migrate to circleci-toolkit v4.0.1 with rolling container images
- Move PRLOG update from PR validation to post-merge on main branch
- Replace bot-commit trigger mechanism with direct API trigger

## Test plan

- [ ] Verify validation workflow runs without `update_prlog`
- [ ] Verify `trigger_success_pipeline` triggers after all validation jobs pass
- [ ] Verify `on_success` workflow runs `end_success`
- [ ] After merge, verify `post_merge_main` workflow triggers on main
- [ ] Confirm PRLOG.md is updated after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)