### PR TITLE
chore: inherit workspace settings in test-utils

### DIFF
--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "test_utils"
 version = "0.19.24"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Summary

- Inherit `edition` and `rust-version` from workspace in `test-utils` crate
- Ensures MSRV consistency across all workspace members

## Changes

- `crates/test-utils/Cargo.toml`: Replace hardcoded `edition = "2021"` with `edition.workspace = true` and add `rust-version.workspace = true`

## Test plan

- [x] `cargo check -p test_utils` passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)