### PR TITLE
fix: anchor version tag regex (#443)

### DIFF
--- a/crates/nextsv/src/main.rs
+++ b/crates/nextsv/src/main.rs
@@ -67,6 +67,9 @@ struct Force {
     /// First flag to set first version and pre-release in the same transaction
     #[arg(short, long)]
     first: bool,
+    /// Prefix string to identify version number tags
+    #[arg(short, long, value_parser, default_value = "v")]
+    prefix: String,
 }
 
 #[derive(Parser, Debug)]
@@ -118,6 +121,7 @@ fn run() -> ExitResult {
 
     match args.command {
         Commands::Force(args) => {
+            calculator_config = calculator_config.set_prefix(&args.prefix);
             calculator_config = calculator_config.set_force_bump(args.bump);
             if args.first {
                 log::debug!("Setting first version and pre-release in the same transaction");

--- a/crates/nextsv/tests/cmd/help.trycmd
+++ b/crates/nextsv/tests/cmd/help.trycmd
@@ -117,11 +117,12 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-  -v, --verbose...  Increase logging verbosity
-  -q, --quiet...    Decrease logging verbosity
-  -f, --first       First flag to set first version and pre-release in the same transaction
-  -h, --help        Print help
-  -V, --version     Print version
+  -v, --verbose...       Increase logging verbosity
+  -q, --quiet...         Decrease logging verbosity
+  -f, --first            First flag to set first version and pre-release in the same transaction
+  -p, --prefix <PREFIX>  Prefix string to identify version number tags [default: v]
+  -h, --help             Print help
+  -V, --version          Print version
 
 ```
 
@@ -204,11 +205,12 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-  -v, --verbose...  Increase logging verbosity
-  -q, --quiet...    Decrease logging verbosity
-  -f, --first       First flag to set first version and pre-release in the same transaction
-  -h, --help        Print help
-  -V, --version     Print version
+  -v, --verbose...       Increase logging verbosity
+  -q, --quiet...         Decrease logging verbosity
+  -f, --first            First flag to set first version and pre-release in the same transaction
+  -p, --prefix <PREFIX>  Prefix string to identify version number tags [default: v]
+  -h, --help             Print help
+  -V, --version          Print version
 
 ```
 


### PR DESCRIPTION
## Summary

- Anchors the version tag regex with `^refs/tags/` so that prefix `v` only matches workspace tags like `refs/tags/v1.0.0` and not crate tags like `refs/tags/gen-changelog-v1.0.0`
- Adds `--prefix` parameter to the `force` subcommand (default `v`, matching `calculate` and `require`) so Force can correctly identify version tags
- Adds 8 unit tests and 6 integration tests covering regex anchoring and prefix isolation

Fixes #443

## Test plan

- [x] 431 lib tests pass (including 8 new regex anchoring tests)
- [x] 4037 repo_tests pass (including 6 new force prefix tests)
- [x] CLI help snapshot tests updated and passing
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)