### PR TITLE
fix: skip merge commits by parent count

### DIFF
--- a/crates/nextsv/src/calculator/commit.rs
+++ b/crates/nextsv/src/calculator/commit.rs
@@ -37,6 +37,10 @@ impl<'a> Commit<'a> {
     //     self.git_commit.time().seconds().to_string()
     // }
 
+    pub(crate) fn is_merge(&self) -> bool {
+        self.git_commit.parents().len() > 1
+    }
+
     pub(crate) fn files(&self) -> Vec<PathBuf> {
         let mut diff_files = vec![];
 

--- a/crates/nextsv/src/calculator/conventional.rs
+++ b/crates/nextsv/src/calculator/conventional.rs
@@ -99,8 +99,8 @@ impl ConventionalCommits {
             let summary = cmt.message();
             log::debug!("commit found: `{summary}`");
 
-            if summary.starts_with("Merge") {
-                log::debug!("Exiting loop as Merge commit found");
+            if cmt.is_merge() {
+                log::debug!("Skipping merge commit: `{summary}`");
                 continue;
             }
 
@@ -112,7 +112,10 @@ impl ConventionalCommits {
                 let dup_files = files.clone();
                 let root_files: Vec<_> = dup_files
                     .iter()
-                    .filter(|file| !file.to_str().unwrap().contains("/"))
+                    .filter(|file| {
+                        let s = file.to_str().unwrap();
+                        !s.contains("/") && (s.ends_with(".toml") || s.ends_with(".lock"))
+                    })
                     .collect();
                 log::debug!("root files: `{root_files:#?}`");
                 let mut qualified_files: Vec<_> = files


### PR DESCRIPTION
## Summary

Two fixes to prevent spurious crate version bumps in multi-crate workspaces:

- **Merge commit detection**: Replace `starts_with("Merge")` string check with `parents().len() > 1` structural check. GitHub PR merge commits use subject lines like `fix(deps): update dependency ... (#N)` which were not being skipped, causing `diff_tree_to_tree(None, ...)` to diff against an empty tree and match all repo files.

- **Root file qualification**: Restrict root-level files that qualify a crate for a version bump to `.toml` and `.lock` extensions only. Previously any root-level file (e.g. `PRLOG.md`, CI config files) in a conventional commit would qualify all crates for a patch bump via the NonProd route.

## Impact

Before this fix, after a Renovate toolkit update PR (merge commit with `fix(deps):` subject) + a PRLOG update commit (`chore: update prlog for pr`), `nextsv calculate -p gen-bsky-v -s crates/gen-bsky` returned `patch` (0.1.10) despite no changes to the gen-bsky source. After this fix it returns `none`.

## Test plan

- [x] `cargo test -p nextsv` — all tests pass
- [x] `cargo fmt --check` — clean
- [x] Manual: `nextsv calculate -p gen-bsky-v -s crates/gen-bsky` in pcu repo returns `none`
- [x] Manual: `nextsv calculate -p pcu-v -s crates/pcu` still returns `patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)