### PR TITLE
chore: modernise CI pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ parameters:
   min_rust_version:
     type: string
     default: "1.82"
-  fingerprint:
-    type: string
-    default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
   validation_flag:
     type: boolean
     default: false
@@ -15,13 +12,9 @@ parameters:
     type: boolean
     default: false
     description: "If true, the success pipeline will be executed."
-  release_flag:
-    type: boolean
-    default: false
-    description: "If true, the release workflow will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.5.0
+  toolkit: jerus-org/circleci-toolkit@4.6.0
 
 workflows:
   check_last_commit:
@@ -30,7 +23,6 @@ workflows:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - not: << pipeline.parameters.success_flag >>
-        - not: << pipeline.parameters.release_flag >>
         - not: << pipeline.parameters.validation_flag >>
 
     jobs:
@@ -45,7 +37,6 @@ workflows:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - not: << pipeline.parameters.success_flag >>
         - << pipeline.parameters.validation_flag >>
-        - not: << pipeline.parameters.release_flag >>
     jobs:
       # Signature verification for trusted PRs (with write access for comments)
       - toolkit/verify_commit_signatures:
@@ -129,73 +120,6 @@ workflows:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - << pipeline.parameters.success_flag >>
         - not: << pipeline.parameters.validation_flag >>
-        - not: << pipeline.parameters.release_flag >>
 
     jobs:
       - toolkit/end_success
-
-  release:
-    when:
-      and:
-        - or:
-            - and:
-                - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-                - equal: ["release check", << pipeline.schedule.name >>]
-            - << pipeline.parameters.release_flag >>
-        - not: << pipeline.parameters.success_flag >>
-        - not: << pipeline.parameters.validation_flag >>
-    jobs:
-      - toolkit/save_next_version:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
-          package: nextsv
-          install_me: true
-          path_to_crate: "./crates/nextsv"
-
-      - toolkit/make_release:
-          requires:
-            - toolkit/save_next_version
-          pre-steps:
-            - attach_workspace:
-                at: /tmp/workspace
-            - run:
-                name: Set SEMVER based on next-version file
-                command: |
-                  set +ex
-                  export SEMVER=$(cat /tmp/workspace/next-version)
-                  echo $SEMVER
-                  echo "export SEMVER=$SEMVER" >> "$BASH_ENV"
-          context:
-            - release
-            - bot-check
-          ssh_fingerprint: << pipeline.parameters.fingerprint >>
-          min_rust_version: << pipeline.parameters.min_rust_version >>
-          package: nextsv
-          when_use_workspace: false
-
-      - toolkit/no_release:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
-          requires:
-            - toolkit/save_next_version:
-                - failed
-
-  post_merge_main:
-    when:
-      and:
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.success_flag >>
-        - not: << pipeline.parameters.validation_flag >>
-        - not: << pipeline.parameters.release_flag >>
-
-    jobs:
-      - toolkit/update_prlog:
-          context:
-            - release
-            - bot-check
-          ssh_fingerprint: << pipeline.parameters.fingerprint >>
-          min_rust_version: << pipeline.parameters.min_rust_version >>
-          update_log_option: halt
-          filters:
-            branches:
-              only:
-                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,6 @@ parameters:
     type: boolean
     default: false
     description: "If true, the validation pipeline will be executed."
-  success_flag:
-    type: boolean
-    default: false
-    description: "If true, the success pipeline will be executed."
 
 orbs:
   toolkit: jerus-org/circleci-toolkit@4.6.0
@@ -22,7 +18,6 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.success_flag >>
         - not: << pipeline.parameters.validation_flag >>
 
     jobs:
@@ -35,7 +30,6 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.success_flag >>
         - << pipeline.parameters.validation_flag >>
     jobs:
       # Signature verification for trusted PRs (with write access for comments)
@@ -57,37 +51,35 @@ workflows:
           filters:
             branches:
               only: /pull\/[0-9]+/
-      - toolkit/label:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
-          context: pcu-app
-          filters:
-            branches:
-              only:
-                - main
-      - toolkit/code_coverage:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
-          package: nextsv
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
-          requires:
-            - security with sonarcloud
       - toolkit/required_builds:
           min_rust_version: << pipeline.parameters.min_rust_version >>
       - toolkit/optional_builds:
           min_rust_version: << pipeline.parameters.min_rust_version >>
+          filters:
+            branches:
+              ignore: main
       - toolkit/test_doc_build:
           min_rust_version: << pipeline.parameters.min_rust_version >>
+          filters:
+            branches:
+              ignore: main
       - toolkit/idiomatic_rust:
           min_rust_version: << pipeline.parameters.min_rust_version >>
+          filters:
+            branches:
+              ignore: main
       - toolkit/common_tests:
           min_rust_version: << pipeline.parameters.min_rust_version >>
+      # security audit only: runs on forked PRs (no secrets exposure) and main
       - toolkit/security:
           name: security audit only
           sonarcloud: false
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only:
+                - main
+                - /pull\/[0-9]+/
+      # security with sonarcloud: runs on trusted feature branches only
       - toolkit/security:
           name: security with sonarcloud
           context: SonarCloud
@@ -96,30 +88,13 @@ workflows:
               ignore:
                 - /pull\/[0-9]+/
                 - main
-      - toolkit/trigger_pipeline:
-          context: bot-check
+      - toolkit/code_coverage:
+          min_rust_version: << pipeline.parameters.min_rust_version >>
+          package: nextsv
           filters:
             branches:
               ignore:
                 - /pull\/[0-9]+/
                 - main
           requires:
-            - verify_commit_signatures_trusted
-            - toolkit/code_coverage
-            - toolkit/idiomatic_rust
-            - toolkit/test_doc_build
-            - toolkit/required_builds
-            - toolkit/common_tests
-            - security audit only
             - security with sonarcloud
-
-  on_success:
-    when:
-      and:
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - << pipeline.parameters.success_flag >>
-        - not: << pipeline.parameters.validation_flag >>
-
-    jobs:
-      - toolkit/end_success

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -1,0 +1,79 @@
+version: 2.1
+
+# Triggered manually or via scheduled pipeline (configured in CircleCI project
+# settings). Runs independently of the push-triggered config.yml.
+#
+# Workflow:
+#   tools             - verify required tools are present and log versions
+#   calculate-versions - calculate next version for nextsv crate and workspace
+#                        BEFORE the approval gate so the reviewer knows exactly
+#                        what will be released; versions are persisted to workspace
+#   approve-release   - manual gate: review calculated versions before approving
+#   release-nextsv    - release nextsv crate (tag: nextsv-v*)
+#   toolkit/release_prlog - create workspace v* release and update PRLOG.md
+
+parameters:
+  nextsv_version:
+    type: string
+    default: ""
+    description: "Override nextsv crate version (empty = nextsv auto-detect)"
+  workspace_version:
+    type: string
+    default: ""
+    description: "Override workspace v* version (empty = nextsv auto-detect)"
+
+orbs:
+  toolkit: jerus-org/circleci-toolkit@4.6.0
+
+jobs:
+  tools:
+    executor:
+      name: toolkit/rust_env_rolling
+    steps:
+      - run:
+          name: Verify tools
+          command: |
+            set -ex
+            nextsv --version
+            pcu --version
+            cargo release --version
+            jq --version
+            rsign --version
+
+workflows:
+  release:
+    jobs:
+      - tools
+
+      # Calculate versions BEFORE the approval gate so the reviewer knows
+      # exactly what will be released. The approved versions are persisted to
+      # the workspace and used unchanged by the release jobs after approval.
+      - toolkit/calculate_versions:
+          name: calculate-versions
+          requires: [tools]
+          crates: "nextsv:nextsv-v"
+          crate_version_overrides: "nextsv:<< pipeline.parameters.nextsv_version >>"
+          workspace_version_override: << pipeline.parameters.workspace_version >>
+
+      - approve-release:
+          type: approval
+          requires: [calculate-versions]
+
+      - toolkit/release_crate:
+          name: release-nextsv
+          requires: [approve-release]
+          package: nextsv
+          crate_tag_prefix: nextsv-v
+          build_binary: true
+          binary_name: nextsv
+          context:
+            - release
+            - bot-check
+            - pcu-app
+
+      - toolkit/release_prlog:
+          requires: [release-nextsv]
+          context:
+            - release
+            - bot-check
+            - pcu-app

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -1,0 +1,41 @@
+version: 2.1
+
+# Triggered by GitHub "pull_request merged" event (configured in CircleCI project
+# settings under "Triggers"). Runs independently of the push-triggered config.yml,
+# so the PRLOG update commit does not re-trigger this workflow.
+#
+# Workflow:
+#   update_prlog  - adds merged PR entry to PRLOG.md, commits and pushes to main
+#   label         - labels the next queued Renovate PR so it is rebased and runs
+
+parameters:
+  min_rust_version:
+    type: string
+    default: "1.82"
+  update_pcu:
+    type: boolean
+    default: true
+    description: "If true, pcu is updated from its main github branch before running."
+
+orbs:
+  toolkit: jerus-org/circleci-toolkit@4.6.0
+
+workflows:
+  update_prlog:
+    jobs:
+      - toolkit/update_prlog:
+          name: update-prlog-on-main
+          context:
+            - release
+            - bot-check
+            - pcu-app
+          min_rust_version: << pipeline.parameters.min_rust_version >>
+          target_branch: "main"
+          pcu_from_merge: --from-merge
+          update_pcu: << pipeline.parameters.update_pcu >>
+          pcu_verbosity: "-vvv"
+      - toolkit/label:
+          min_rust_version: << pipeline.parameters.min_rust_version >>
+          context: pcu-app
+          requires:
+            - update-prlog-on-main


### PR DESCRIPTION
## Summary

Splits the monolithic `config.yml` into separate pipeline files, matching the pattern established in pcu and gen-changelog.

## Changes

**New `update_prlog.yml`**
- Triggered by GitHub "pr merged" event
- Uses `toolkit/update_prlog@4.6.0` with `target_branch: "main"` and `pcu_from_merge: --from-merge`
- No SSH key required — pcu uses GitHub App token directly

**New `release.yml`**
- Triggered manually or by scheduled pipeline
- `toolkit/calculate_versions` shows versions before approval gate
- `toolkit/release_crate` handles nextsv crate release (with binary signing)
- `toolkit/release_prlog` creates workspace v* tag and updates PRLOG

**Updated `config.yml`**
- Remove `fingerprint` and `release_flag` parameters
- Remove `release` and `post_merge_main` workflows
- Bump toolkit to 4.6.0

## Test plan

- [ ] CI passes on this PR (validation workflow)
- [ ] After merge: "pr merged" event triggers `update_prlog` workflow correctly
- [ ] Release pipeline triggers correctly from CircleCI project settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)