### PR TITLE
chore: switch to rolling build jobs and bump toolkit to 4.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "1.82"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.6.0
+  toolkit: jerus-org/circleci-toolkit@4.7.0
 
 workflows:
   validation:
@@ -30,7 +30,7 @@ workflows:
           filters:
             branches:
               only: /pull\/[0-9]+/
-      - toolkit/required_builds:
+      - toolkit/required_builds_rolling:
           min_rust_version: << pipeline.parameters.min_rust_version >>
       - toolkit/optional_builds:
           min_rust_version: << pipeline.parameters.min_rust_version >>
@@ -47,7 +47,7 @@ workflows:
           filters:
             branches:
               ignore: main
-      - toolkit/common_tests:
+      - toolkit/common_tests_rolling:
           min_rust_version: << pipeline.parameters.min_rust_version >>
       # security audit only: runs on forked PRs (no secrets exposure) and main
       - toolkit/security:


### PR DESCRIPTION
## Summary

- Bump `circleci-toolkit` to `4.7.0`
- Replace `toolkit/required_builds` → `toolkit/required_builds_rolling`
- Replace `toolkit/common_tests` → `toolkit/common_tests_rolling`

Both rolling jobs use the `jerusdp/ci-rust:rolling-6mo` container (digest-pinned, covers the last 6 months of Rust releases) and call `select_rust_version` to resolve the MSRV against the oldest toolchain available — eliminating the need for per-version pinned container images.

## Test plan

- [ ] CI passes on this branch
- [ ] `required_builds_rolling` builds with both `stable` and the fallback MSRV version
- [ ] `common_tests_rolling` runs tests on the resolved MSRV toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)