### PR TITLE
chore: update toolkit to 4.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "1.82"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.0
+  toolkit: jerus-org/circleci-toolkit@4.7.1
 
 workflows:
   validation:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.0
+  toolkit: jerus-org/circleci-toolkit@4.7.1
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -18,7 +18,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.0
+  toolkit: jerus-org/circleci-toolkit@4.7.1
 
 workflows:
   update_prlog:


### PR DESCRIPTION
## Summary

- Update circleci-toolkit orb from 4.7.0 to 4.7.1
- 4.7.1 includes fix for toolkit/label CIRCLE_PULL_REQUEST guard that silently blocked pcu label in the pr-merged event pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)