### PR TITLE
fix: use container pcu in update_prlog

### DIFF
--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -14,7 +14,7 @@ parameters:
     default: "1.82"
   update_pcu:
     type: boolean
-    default: true
+    default: false
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:


### PR DESCRIPTION
## Summary

- Change `update_pcu` default from `true` → `false` in `update_prlog.yml`

The ci-container already has pcu pre-installed. The `update_prlog` job has no reason to rebuild it from source on every post-merge run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)