### PR TITLE
chore: update circleci-toolkit to 5.3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "1.82"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.1
+  toolkit: jerus-org/circleci-toolkit@5.3.9
 
 workflows:
   validation:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.1
+  toolkit: jerus-org/circleci-toolkit@5.3.9
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -18,7 +18,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.1
+  toolkit: jerus-org/circleci-toolkit@5.3.9
 
 workflows:
   update_prlog:
@@ -29,13 +29,4 @@ workflows:
             - release
             - bot-check
             - pcu-app
-          min_rust_version: << pipeline.parameters.min_rust_version >>
-          target_branch: "main"
-          pcu_from_merge: --from-merge
-          update_pcu: << pipeline.parameters.update_pcu >>
-          pcu_verbosity: "-vvv"
       - toolkit/label:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
-          context: pcu-app
-          requires:
-            - update-prlog-on-main


### PR DESCRIPTION
## Summary

- Updates `jerus-org/circleci-toolkit` from 4.7.1 to 5.3.9 across all 3 CI files
- Removes `min_rust_version` from `toolkit/update_prlog` and `toolkit/label` (parameter removed in 5.0.0; label now runs inline in `update_prlog`)
- Structural changes applied via `circleci-toolkit-mcp` `apply_migration` tool

## Test plan

- [ ] CircleCI lint passes on PR branch
- [ ] After merge: `update_prlog` workflow fires and completes
- [ ] After merge: next feature branch push triggers successful `validation` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)