### PR TITLE
chore: update circleci-toolkit to 5.3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "1.82"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.1
+  toolkit: jerus-org/circleci-toolkit@5.3.10
 
 workflows:
   validation:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.1
+  toolkit: jerus-org/circleci-toolkit@5.3.10
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -9,16 +9,13 @@ version: 2.1
 #   label         - labels the next queued Renovate PR so it is rebased and runs
 
 parameters:
-  min_rust_version:
-    type: string
-    default: "1.82"
   update_pcu:
     type: boolean
     default: false
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.1
+  toolkit: jerus-org/circleci-toolkit@5.3.10
 
 workflows:
   update_prlog:
@@ -29,13 +26,11 @@ workflows:
             - release
             - bot-check
             - pcu-app
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           target_branch: "main"
           pcu_from_merge: --from-merge
           update_pcu: << pipeline.parameters.update_pcu >>
           pcu_verbosity: "-vvv"
       - toolkit/label:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           context: pcu-app
           requires:
             - update-prlog-on-main


### PR DESCRIPTION
## Summary

- Updates `jerus-org/circleci-toolkit` from `4.7.1` to `5.3.10` in all three CI files
- Removes `min_rust_version` parameter from `toolkit/update_prlog` and `toolkit/label` (removed in 5.0.0)
- Removes orphaned `min_rust_version` pipeline parameter declaration from `update_prlog.yml`

## Test plan

- [ ] CI passes on push pipeline
- [ ] update_prlog and label jobs run correctly on next PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)