### PR TITLE
chore: migrate CI to circleci-toolkit 6.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "1.82"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.1
+  toolkit: jerus-org/circleci-toolkit@6.0.0
 
 workflows:
   validation:
@@ -30,24 +30,21 @@ workflows:
           filters:
             branches:
               only: /pull\/[0-9]+/
-      - toolkit/required_builds_rolling:
+      - toolkit/required_builds:
           min_rust_version: << pipeline.parameters.min_rust_version >>
       - toolkit/optional_builds:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           filters:
             branches:
               ignore: main
       - toolkit/test_doc_build:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           filters:
             branches:
               ignore: main
       - toolkit/idiomatic_rust:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           filters:
             branches:
               ignore: main
-      - toolkit/common_tests_rolling:
+      - toolkit/common_tests:
           min_rust_version: << pipeline.parameters.min_rust_version >>
       # security audit only: runs on forked PRs (no secrets exposure) and main
       - toolkit/security:
@@ -68,7 +65,6 @@ workflows:
                 - /pull\/[0-9]+/
                 - main
       - toolkit/code_coverage:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           package: nextsv
           filters:
             branches:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.1
+  toolkit: jerus-org/circleci-toolkit@6.0.0
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -9,16 +9,13 @@ version: 2.1
 #   label         - labels the next queued Renovate PR so it is rebased and runs
 
 parameters:
-  min_rust_version:
-    type: string
-    default: "1.82"
   update_pcu:
     type: boolean
     default: false
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@4.7.1
+  toolkit: jerus-org/circleci-toolkit@6.0.0
 
 workflows:
   update_prlog:
@@ -29,13 +26,11 @@ workflows:
             - release
             - bot-check
             - pcu-app
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           target_branch: "main"
           pcu_from_merge: --from-merge
           update_pcu: << pipeline.parameters.update_pcu >>
           pcu_verbosity: "-vvv"
       - toolkit/label:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
           context: pcu-app
           requires:
             - update-prlog-on-main


### PR DESCRIPTION
## Summary

- Migrate all 3 CI files from `jerus-org/circleci-toolkit@4.7.1` to `6.0.0`
- Rename `required_builds_rolling` → `required_builds`
- Rename `common_tests_rolling` → `common_tests`
- Remove `min_rust_version` from jobs that no longer accept it (`optional_builds`, `test_doc_build`, `idiomatic_rust`, `code_coverage`, `label`, `update_prlog`)
- Remove orphaned `min_rust_version` pipeline parameter from `update_prlog.yml`

## Test plan

- [ ] CI passes on this branch with toolkit 6.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)