### PR TITLE
fix(deps): patch RUSTSEC-2026-0204 (crossbeam-epoch) + RUSTSEC-2026-0190 (anyhow)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Two advisories that landed in the RustSec DB and are both failing `cargo audit` on this repo:

| Advisory | Crate | Fix |
|---|---|---|
| RUSTSEC-2026-0204 | `crossbeam-epoch` 0.9.18 (transitive, via rayon/moka) | → 0.9.20 |
| RUSTSEC-2026-0190 | `anyhow` 1.0.102 — `Error::downcast_mut()` unsoundness (UB) | → 1.0.103 |

Lockfile-only. Verified: `cargo audit` clean, `clippy --all --tests --all-features -D warnings` clean, `fmt --check` clean, tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
