### PR TITLE
fix: bump MSRV 1.82 -> 1.87

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   min_rust_version:
     type: string
-    default: "1.82"
+    default: "1.87"
 
 orbs:
   toolkit: jerus-org/circleci-toolkit@6.4.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 authors = ["jerusdp <jrussell@jerus.ie>"]
-rust-version = "1.82"
+rust-version = "1.87"
 repository = "https://github.com/jerusdp/nextsv"
 
 [workspace.dependencies]

--- a/crates/nextsv/README.md
+++ b/crates/nextsv/README.md
@@ -3,7 +3,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][circleci-badge]][circleci-url]
-[![Rust 1.82+][version-badge]][version-url]
+[![Rust 1.87+][version-badge]][version-url]
 [![FOSSA Status][fossa-badge]][fossa-url]
 [![Docs][docs-badge]][docs-url]
 [![BuyMeaCoffee][bmac-badge]][bmac-url]
@@ -16,7 +16,7 @@
 [mit-url]: https://github.com/jerusdp/nextsv/blob/main/LICENSE
 [circleci-badge]:https://circleci.com/gh/jerusdp/nextsv/tree/main.svg?style=svg
 [circleci-url]: https://circleci.com/gh/jerusdp/nextsv/tree/?branch=main
-[version-badge]: https://img.shields.io/badge/rust-1.82+-orange.svg
+[version-badge]: https://img.shields.io/badge/rust-1.87+-orange.svg
 [version-url]: https://www.rust-lang.org
 [fossa-badge]: https://app.fossa.com/api/projects/custom%2B22707%2Fgithub.com%2Fjerusdp%2Fnextsv.svg?type=shield
 [fossa-url]: https://app.fossa.com/projects/custom%2B22707%2Fgithub.com%2Fjerusdp%2Fnextsv?ref=badge_shield


### PR DESCRIPTION
## What & why

The declared MSRV of **1.82 no longer builds**. Two dependencies have raised the
real floor:

- `clap_derive 4.6.1` requires the `edition2024` Cargo feature (stabilized in
  Rust **1.85**);
- `git2` uses a feature gated to Rust **1.87** (`E0658`).

`cargo msrv find` reports the true minimum as **1.87.0**.

## Why CI didn't catch it

CI's "minimum" build runs on a **rolling** toolchain (current stable − 4, floored
at 1.70) — typically far newer than the declared `rust-version`. So when a
dependency bump quietly raises the floor, CI stays green while the documented
MSRV is already broken. `cargo msrv verify` (which builds at the declared
`rust-version` against the locked deps) is the source of truth, and it was
failing at 1.82.

## Change

Bump the MSRV to **1.87** in lockstep across the three places that must agree:

- `Cargo.toml` — workspace `rust-version`
- `.circleci/config.yml` — `min_rust_version` parameter default
- `crates/nextsv/README.md` — version badge

## Verification

`cargo msrv verify --manifest-path crates/nextsv/Cargo.toml` → **Rust 1.87.0: Is
compatible.** No functional/code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
